### PR TITLE
Add graceful-fs to avoid Error: EMFILE: too many open files

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,10 @@
 
 var process = require('process');
 var fs = require('fs');
+
+const gracefulFs = require('graceful-fs');
+gracefulFs.gracefulify(fs);
+
 var path = require('path');
 var globby = require('globby');
 var crypto = require('crypto');

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "dependencies": {
     "chalk": "^1.1.1",
     "checksum": "^0.1.1",
-    "globby": "^4.0.0"
+    "globby": "^4.0.0",
+    "graceful-fs": "^4.1.11"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
This pr addresses the issue where too many files are opened at a time while assessing whether the files have changed. Is useful when trying to decide whether to run npm install when packages.json changes, and your 'out:' includes node_packages.